### PR TITLE
some small improvements

### DIFF
--- a/lib/url-search-params.ts
+++ b/lib/url-search-params.ts
@@ -5,15 +5,11 @@ import {
   CODE_SPACE,
 } from './const';
 
-interface IRecord {
-  [key: string]: string;
-}
-
 export default class URLSearchParams implements IURLSearchParams {
   public params: Array<[string, string]>;
   public isEncoded = false;
 
-  constructor(init?: string | Array<[string, string]> | IRecord) {
+  constructor(init?: string | Array<[string, string]> | Record<string, string>) {
     this.params = [];
     if (typeof init === 'string') {
       extractParams(

--- a/lib/url-search-params.ts
+++ b/lib/url-search-params.ts
@@ -2,8 +2,6 @@ import { URLSearchParams as IURLSearchParams } from 'url';
 import {
   CODE_AMPERSAND,
   CODE_EQUALS,
-  CODE_HASH,
-  CODE_PLUS,
   CODE_SPACE,
 } from './const';
 
@@ -67,7 +65,7 @@ export default class URLSearchParams implements IURLSearchParams {
       callback(optionalDecode(value), optionalDecode(key), this);
     });
   }
-  public get(name: string): string {
+  public get(name: string): string | null {
     const entry = this.params.find(([k, _]) => optionalDecode(k) === name);
     if (entry) {
       return optionalDecode(entry[1]);
@@ -141,7 +139,7 @@ export function extractParams(
   let valStart = 0;
   const appendParams = encode
     ? params.append.bind(params)
-    : (n, v) => params.params.push([n, v]);
+    : (n: string, v: string) => params.params.push([n, v]);
 
   for (; index <= end; index += 1) {
     const code = urlString.charCodeAt(index);

--- a/lib/url-search-params.ts
+++ b/lib/url-search-params.ts
@@ -35,13 +35,12 @@ export default class URLSearchParams implements IURLSearchParams {
     }
   }
 
-  public *entries() {
+  public *entries(): IterableIterator<[string, string]> {
     for (let i = 0; i < this.params.length; i += 1) {
-      const decoded: [string, string] = [
+      yield [
         optionalDecode(this.params[i][0]),
         optionalDecode(this.params[i][1]),
       ];
-      yield decoded;
     }
   }
 
@@ -54,6 +53,7 @@ export default class URLSearchParams implements IURLSearchParams {
       ([key, _]) => optionalDecode(key) !== name,
     );
   }
+
   public forEach(
     callback: (value: string, name: string, searchParams: this) => void,
   ): void {
@@ -61,6 +61,7 @@ export default class URLSearchParams implements IURLSearchParams {
       callback(optionalDecode(value), optionalDecode(key), this);
     });
   }
+
   public get(name: string): string | null {
     const entry = this.params.find(([k, _]) => optionalDecode(k) === name);
     if (entry) {
@@ -68,14 +69,17 @@ export default class URLSearchParams implements IURLSearchParams {
     }
     return null;
   }
+
   public getAll(name: string): string[] {
     return this.params
       .filter(([key, _]) => optionalDecode(key) === name)
       .map(kv => kv[1]);
   }
+
   public has(name: string): boolean {
     return this.get(name) !== null;
   }
+
   public *keys(): IterableIterator<string> {
     for (let i = 0; i < this.params.length; i += 1) {
       yield optionalDecode(this.params[i][0]);
@@ -103,17 +107,21 @@ export default class URLSearchParams implements IURLSearchParams {
       encodeParameter(value),
     ]);
   }
+
   public sort(): void {
     this.params = this.params.sort((a, b) => a[0].localeCompare(b[0]));
   }
+
   public toString(): string {
     return this.params.map(([k, v]) => `${k}=${v}`).join('&');
   }
+
   public *values(): IterableIterator<string> {
     for (let i = 0; i < this.params.length; i += 1) {
       yield optionalDecode(this.params[i][1]);
     }
   }
+
   public [Symbol.iterator](): IterableIterator<[string, string]> {
     return this.entries();
   }
@@ -171,7 +179,7 @@ export function extractParams(
 
 function decodeURIComponentSafe(s: string): string {
   try {
-    return decodeURIComponent(s.replace('+', ' '));
+    return decodeURIComponent(s.replace(/\+/g, ' '));
   } catch (e) {
     return s;
   }

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -23,8 +23,8 @@ function isValidProtocolChar(code: number) {
     (code >= 97 && code <= 122) || // a-z
     (code >= 48 && code <= 57) || // 0-9
     code === 45 || // -
-    code === 43 // +
-  );
+    code === 43
+  ); // +
 }
 
 /**
@@ -47,27 +47,27 @@ function isValidProtocolChar(code: number) {
  * See also for common API: https://developer.mozilla.org/en-US/docs/Web/API/URL
  */
 export default class URL implements IURL {
-  public origin: string = 'null';
-  public slashes: string = '';
+  public origin: string;
+  public slashes: string;
 
-  private _protocol: string = '';
-  private _username: string = '';
-  private _password: string = '';
-  private _hostname: string = '';
-  private _host: string = '';
-  private _port: string = '';
-  private _pathname: string = '';
-  private _search: string = '';
-  private _hash: string = '';
-  private _href: string = '';
+  private _protocol: string;
+  private _username: string;
+  private _password: string;
+  private _hostname: string;
+  private _host: string;
+  private _port: string;
+  private _pathname: string;
+  private _search: string;
+  private _hash: string;
+  private _href: string;
 
-  private parameterStartIndex: number = 0;
-  private queryStartIndex: number = 0;
-  private isQueryParsed: boolean = false;
-  private _parameters: URLSearchParams = new URLSearchParams();
-  private _query: URLSearchParams = new URLSearchParams();
-  private _domainInfo: IResult | null = null;
-  private parsedParameters: URLSearchParams | null = null;
+  private parameterStartIndex: number;
+  private queryStartIndex: number;
+  private isQueryParsed: boolean;
+  private _parameters: URLSearchParams;
+  private _query: URLSearchParams;
+  private _domainInfo: IResult | null;
+  private parsedParameters: URLSearchParams | null;
 
   constructor(url: string) {
     this.parse(url);
@@ -539,9 +539,26 @@ export default class URL implements IURL {
   }
 
   private parse(url: string) {
-    if (!url) {
+    if (typeof url !== 'string' || url.length === 0) {
       throw new TypeError(`${url} is not a valid URL`);
     }
+
+    this._protocol = '';
+    this._hostname = '';
+    this._host = '';
+    this._port = '';
+    this._pathname = '';
+    this._username = '';
+    this._password = '';
+    this._search = '';
+    this._hash = '';
+    this.parameterStartIndex = 0;
+    this.queryStartIndex = 0;
+    this.isQueryParsed = false;
+    this._parameters = new URLSearchParams();
+    this._query = new URLSearchParams();
+    this._domainInfo = null;
+    this.parsedParameters = null;
 
     let index = 0;
     // end is within bound of url

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -23,8 +23,8 @@ function isValidProtocolChar(code: number) {
     (code >= 97 && code <= 122) || // a-z
     (code >= 48 && code <= 57) || // 0-9
     code === 45 || // -
-    code === 43
-  ); // +
+    code === 43 // +
+  );
 }
 
 /**
@@ -47,27 +47,27 @@ function isValidProtocolChar(code: number) {
  * See also for common API: https://developer.mozilla.org/en-US/docs/Web/API/URL
  */
 export default class URL implements IURL {
-  public origin: string;
-  public slashes: string;
+  public origin: string = 'null';
+  public slashes: string = '';
 
-  private _protocol: string;
-  private _username: string;
-  private _password: string;
-  private _hostname: string;
-  private _host: string;
-  private _port: string;
-  private _pathname: string;
-  private _search: string;
-  private _hash: string;
-  private _href: string;
+  private _protocol: string = '';
+  private _username: string = '';
+  private _password: string = '';
+  private _hostname: string = '';
+  private _host: string = '';
+  private _port: string = '';
+  private _pathname: string = '';
+  private _search: string = '';
+  private _hash: string = '';
+  private _href: string = '';
 
-  private parameterStartIndex: number;
-  private queryStartIndex: number;
-  private isQueryParsed: boolean;
-  private _parameters: URLSearchParams;
-  private _query: URLSearchParams;
-  private _domainInfo: IResult;
-  private parsedParameters: URLSearchParams;
+  private parameterStartIndex: number = 0;
+  private queryStartIndex: number = 0;
+  private isQueryParsed: boolean = false;
+  private _parameters: URLSearchParams = new URLSearchParams();
+  private _query: URLSearchParams = new URLSearchParams();
+  private _domainInfo: IResult | null = null;
+  private parsedParameters: URLSearchParams | null = null;
 
   constructor(url: string) {
     this.parse(url);
@@ -364,7 +364,7 @@ export default class URL implements IURL {
     return this.parsedParameters;
   }
 
-  private _extractHostname(start, end) {
+  private _extractHostname(start: number, end: number): number {
     let portIndex = 0;
     let stopped = false;
     let i = start;
@@ -542,22 +542,6 @@ export default class URL implements IURL {
     if (!url) {
       throw new TypeError(`${url} is not a valid URL`);
     }
-    this._protocol = null;
-    this._hostname = null;
-    this._host = null;
-    this._port = '';
-    this._pathname = null;
-    this._username = '';
-    this._password = '';
-    this._search = '';
-    this._hash = '';
-    this.parameterStartIndex = 0;
-    this.queryStartIndex = 0;
-    this.isQueryParsed = false;
-    this._parameters = new URLSearchParams();
-    this._query = new URLSearchParams();
-    this._domainInfo = null;
-    this.parsedParameters = null;
 
     let index = 0;
     // end is within bound of url

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,7 +4,7 @@ import URL from './url';
  * Checks if this URL's hostname is non-ascii, and if so returns a new URL with the hostname
  * punycoded. Otherwise returns itself.
  */
-export function getPunycodeEncoded(toASCII: (s) => string, url: URL) {
+export function getPunycodeEncoded(toASCII: (s: string) => string, url: URL) {
   const punycodedHost = toASCII(url.hostname);
   if (punycodedHost !== url.hostname) {
     return new URL(`${url.protocol}${url.slashes}${punycodedHost}${url.pathname}${url.search}${url.hash}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2772,15 +2772,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-reference": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.2.tgz",
-      "integrity": "sha512-Kn5g8c7XHKejFOpTf2QN9YjiHHKl5xRj+2uAZf9iM2//nkBNi/NNeB5JMoun28nEaUVHyPUzqzhfRlfAirEjXg==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39"
-      }
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -4443,19 +4434,6 @@
           "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         }
-      }
-    },
-    "rollup-plugin-commonjs": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.1.tgz",
-      "integrity": "sha512-x0PcCVdEc4J8igv1qe2vttz8JKAKcTs3wfIA3L8xEty3VzxgORLrzZrNWaVMc+pBC4U3aDOb9BnWLAQ8J11vkA==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "jest": "^24.8.0",
     "punycode": "^2.1.1",
     "rollup": "^1.16.2",
-    "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-node-resolve": "^5.1.0",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",

--- a/test/url-search-params.test.ts
+++ b/test/url-search-params.test.ts
@@ -1,6 +1,9 @@
-import { URLSearchParams as IURLSearchParams } from 'url';
+import { URLSearchParams as NodeURLSearchParams } from 'url';
+// @ts-ignore
 import { URLSearchParams } from 'whatwg-url';
 import { URLSearchParams as TestURLSearchParams } from '../url-parser';
+
+type IURLSearchParams = NodeURLSearchParams | URLSearchParams | TestURLSearchParams;
 
 describe('URLSearchParams', () => {
   function testParamsEquals(
@@ -41,19 +44,19 @@ describe('URLSearchParams', () => {
     });
 
     it('with string init value', () => {
-      testURLSearchParams(null, '?foo=1&bar=2');
+      testURLSearchParams(undefined, '?foo=1&bar=2');
     });
 
     it('with string init value (no preceiding ?)', () => {
-      testURLSearchParams(null, 'foo=1&bar=2');
+      testURLSearchParams(undefined, 'foo=1&bar=2');
     });
 
     it('with array init value', () => {
-      testURLSearchParams(null, [['foo', '1'], ['bar', 2]]);
+      testURLSearchParams(undefined, [['foo', '1'], ['bar', 2]]);
     });
 
     it('with record init value', () => {
-      testURLSearchParams(null, { foo: 1 , bar: 2});
+      testURLSearchParams(undefined, { foo: 1 , bar: 2});
     });
   });
 
@@ -76,15 +79,15 @@ describe('URLSearchParams', () => {
   describe('#entries', () => {
     it('iterates key-value pairs', () => {
       // tested in testParamsEquals function
-      testURLSearchParams(null, 'key1=value1&key2=value2');
+      testURLSearchParams(undefined, 'key1=value1&key2=value2');
     });
   });
 
   describe('#forEach', () => {
     it('calls callback with each key-value pair', () => {
       testURLSearchParams(params => {
-        const iteratedParams = [];
-        params.forEach((value, key) => {
+        const iteratedParams: string[] = [];
+        params.forEach((value: string, key: string) => {
           iteratedParams.push(`${key}=${value}`);
         });
         expect(iteratedParams.join('&')).toBe('key1=value1&key2=value2');
@@ -137,13 +140,13 @@ describe('URLSearchParams', () => {
   describe('#keys', () => {
     it('returns all keys', () => {
       testURLSearchParams(params => {
-        expect([...params.keys()]).toEqual(['key1', 'key2']);
+        expect(Array.from(params.keys())).toEqual(['key1', 'key2']);
       }, 'key1=value1&key2=value2');
     });
 
     it('keys are repeated', () => {
       testURLSearchParams(params => {
-        expect([...params.keys()]).toEqual(['key1', 'key2', 'key1']);
+        expect(Array.from(params.keys())).toEqual(['key1', 'key2', 'key1']);
       }, 'key1=value1&key2=value2&key1=value2');
     });
   });
@@ -198,7 +201,7 @@ describe('URLSearchParams', () => {
   describe('#values', () => {
     it('iterates parameter values', () => {
       testURLSearchParams(params => {
-        expect([...params.values()]).toEqual(['value1', 'value2']);
+        expect(Array.from(params.values())).toEqual(['value1', 'value2']);
       }, 'key1=value1&key2=value2');
     });
   });

--- a/test/url-spec.test.ts
+++ b/test/url-spec.test.ts
@@ -53,6 +53,8 @@ describe('URL Spec', () => {
     'HTTP://CAPS.EXAMPLE.COM/WhAT?',
     'http://xn--mnchen-3ya.de/',
     'https://example.com/page%201?q=2%20%2B%202%20%3D%205',
+    'https://example.com/?q=+33%201',
+    'https://example.com/?q=+33+%201',
   ].forEach((urlString: string) => {
     it(urlString, () => {
       const expected = new URLSpec(urlString);

--- a/test/url-spec.test.ts
+++ b/test/url-spec.test.ts
@@ -1,9 +1,10 @@
 import { toASCII } from 'punycode';
+// @ts-ignore
 import { URL as URLSpec } from 'whatwg-url';
 import { getPunycodeEncoded, URL } from '../url-parser';
 
 describe('URL Spec', () => {
-  function compareParameters(u1, u2) {
+  function compareParameters(u1: URLSpec, u2: URL) {
     const url1Params = u1.searchParams.entries();
     const url2Params = u2.searchParams.entries();
     let param1 = url1Params.next();
@@ -17,7 +18,7 @@ describe('URL Spec', () => {
     }
   }
 
-  function testURLEquals(actual, expected) {
+  function testURLEquals(actual: URL, expected: URLSpec) {
     expect(actual.hash).toBe(expected.hash);
     expect(actual.host).toBe(expected.host);
     expect(actual.hostname).toBe(expected.hostname);
@@ -73,9 +74,10 @@ describe('URL Spec', () => {
     '/test',
     'https://[::-1]foobar:42/',
     'http//example.com',
-  ].forEach((urlString: string) => {
+  ].forEach((urlString: string | undefined | null | number | boolean) => {
     it(`throws for ${urlString}`, () => {
       expect(() => new URLSpec(urlString)).toThrow();
+      // @ts-ignore
       expect(() => new URL(urlString)).toThrow();
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "build/types",
-    "types": ["node", "jest"],
     "target": "es5",
     "module": "es6",
     "outDir": "build",
     "lib": ["es6"],
     "moduleResolution": "Node",
+    "esModuleInterop": true,
     "importHelpers": true,
     "downlevelIteration": true,
     "allowUnreachableCode": false,
@@ -18,7 +18,8 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strict": true
+    "strict": true,
+    "strictPropertyInitialization": false
   },
   "files": [
     "./url-parser.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,17 @@
     "moduleResolution": "Node",
     "importHelpers": true,
     "downlevelIteration": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "forceConsistentCasingInFileNames": true,
+    "keyofStringsOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true
   },
   "files": [
-    "./url-parser.ts",
+    "./url-parser.ts"
   ]
 }


### PR DESCRIPTION
The goal of this PR is to enable stricter TypeScript flag which enforce more type consistency overall (no implicit any, etc.). The only option which is currently disabled is `strictPropertyInitialization` which would require properties initialization in `URL` to be duplicated in `constructor` and `parse`.

* remove un-needed rollup-plugin-commonjs dependency
* enable strict flags in tsconfig.json
* fix implicity any type in utils.ts
* fix typescript errors in url-search-params
* fix typescript errors in url.ts
* fix typescript errors with stricter config
* make use of built-in Record instead of IRecord 