### PR TITLE
Update tldts + fix security issue

### DIFF
--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,5 +1,4 @@
-import { parse } from 'tldts';
-import { IResult } from 'tldts/dist/lib/factory';
+import { parse } from 'tldts-experimental';
 import { URL as IURL } from 'url';
 import {
   CODE_AMPERSAND,
@@ -14,6 +13,8 @@ import {
   CODE_SQUARE_BRACKET_OPEN,
 } from './const';
 import URLSearchParams, { extractParams } from './url-search-params';
+
+type IResult = ReturnType<typeof parse>;
 
 const BREAK_HOST_ON = [CODE_FORWARD_SLASH, CODE_HASH, CODE_QUESTION_MARK];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,9 +3538,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.sortby": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,10 +4989,18 @@
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
-    "tldts": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.2.0.tgz",
-      "integrity": "sha512-rtC2feorWA6Waa/sD7lWTPwi4UMXG08pvhuAms5HRGMthHm4dZPmc3Tar/T8o5aAicNQJjvakWQqSJN1qn2HAw=="
+    "tldts-core": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.3.1.tgz",
+      "integrity": "sha512-z8C2wcT2XvSgk5p0HWapXPkvvKG7E8Jei71N+9Mpp9Eoh2/wjtQPhDeENSuzHNmjTdRz6KFIcM7aWTB+7g0OyA=="
+    },
+    "tldts-experimental": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-5.3.1.tgz",
+      "integrity": "sha512-sbNyh4NCN08kwnVKNTcTiPxMlAGK9PqnXDzIAPLHWflsD8Kyd7CnohgIXExd9CN91paldIWRR7sOtVmMfw5SfQ==",
+      "requires": {
+        "tldts-core": "^5.3.1"
+      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "whatwg-url": "^7.0.0"
   },
   "dependencies": {
-    "tldts": "^5.0.3"
+    "tldts-experimental": "^5.3.1"
   }
 }


### PR DESCRIPTION
> tldts-experimental exposes the exact same API as tldts bundle and is
> validated using the same exhaustive test suit. It differs by using a
> much more compact representation for rules using typed arrays. It can
> also produce (unlikely) collisions. In exchange, performance is much
> better, bundle is smaller and loads faster.

@sammacbeth what do you think about setting-up `dependabot` for this project. I already use it on multiple projects and it is really nice: it creates PR to automatically update dependencies for the project.