### PR TITLE
Throw error for invalid ports

### DIFF
--- a/lib/url.ts
+++ b/lib/url.ts
@@ -431,6 +431,7 @@ export default class URL implements IURL {
     if (portIndex > 0) {
       i += 1;
       const portStart = i;
+      let nonNumeric = false;
       for (; i <= end; i += 1) {
         const code = this._href.charCodeAt(i);
         if (BREAK_HOST_ON.indexOf(code) !== -1) {
@@ -442,10 +443,21 @@ export default class URL implements IURL {
           this._username = this._href.slice(start, portIndex || i);
           this._password = this._href.slice(portIndex + 1, i);
           return this._extractHostname(i + 1, end);
+        } else if (code < 48 || code > 57) {
+          // non numeric character in port
+          nonNumeric = true;
         }
       }
       if (!this._port) {
         this._port = this.href.slice(portStart, i);
+      }
+      // validate port - cannot contain non-numeric characters
+      if (nonNumeric) {
+        throw new TypeError('Invalid URL: port contains non numeric character');
+      }
+      // cannot be greater than 65535
+      if (this._port.length >= 5 && +this._port > 65535) {
+        throw new TypeError('Invalid URL: invalid port number');
       }
     }
     this._host = this._href.slice(start, !stopped ? i + 1 : i);

--- a/test/url-spec.test.ts
+++ b/test/url-spec.test.ts
@@ -55,6 +55,7 @@ describe('URL Spec', () => {
     'https://example.com/page%201?q=2%20%2B%202%20%3D%205',
     'https://example.com/?q=+33%201',
     'https://example.com/?q=+33+%201',
+    'https://[::1]/',
   ].forEach((urlString: string) => {
     it(urlString, () => {
       const expected = new URLSpec(urlString);
@@ -76,6 +77,8 @@ describe('URL Spec', () => {
     '/test',
     'https://[::-1]foobar:42/',
     'http//example.com',
+    'http://data:text/plain;charset=UTF-8;page=21,the%20data:1234,5678',
+    'http://example.com:65536/',
   ].forEach((urlString: string | undefined | null | number | boolean) => {
     it(`throws for ${urlString}`, () => {
       expect(() => new URLSpec(urlString)).toThrow();


### PR DESCRIPTION
If the port specified in the URL is not numeric, or greater than 2^16, the URL constructor should throw. This PR adds checks for these cases.

Fixes #5. Adds test to verify #6 is working.