### PR TITLE
Remove dependency to tslib by bumping TypeScript target

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      tsConfig: 'tsconfig.json',
-    },
-  },
 };

--- a/lib/immutable-url.ts
+++ b/lib/immutable-url.ts
@@ -1,5 +1,4 @@
 import { parse } from 'tldts-experimental';
-import { URL as IURL } from 'url';
 import {
   CODE_AMPERSAND,
   CODE_AT,
@@ -12,6 +11,7 @@ import {
   CODE_SQUARE_BRACKET_CLOSE,
   CODE_SQUARE_BRACKET_OPEN,
 } from './const';
+import { IURLExtended } from './types';
 import URLSearchParams, { extractParams } from './url-search-params';
 
 type IResult = ReturnType<typeof parse>;
@@ -47,7 +47,7 @@ function isValidProtocolChar(code: number) {
  *
  * See also for common API: https://developer.mozilla.org/en-US/docs/Web/API/URL
  */
-export default class ImmutableURL implements IURL {
+export default class implements IURLExtended {
   public origin: string;
   public slashes: string;
 

--- a/lib/search-params-wrapper.ts
+++ b/lib/search-params-wrapper.ts
@@ -1,4 +1,4 @@
-import { URL } from 'url';
+import { IURLExtended } from './types';
 import URLSearchParams from './url-search-params';
 
 /**
@@ -6,7 +6,7 @@ import URLSearchParams from './url-search-params';
  * URL instance.
  */
 export default class URLSearchParamsWrapper extends URLSearchParams {
-  constructor(private url: URL, init: URLSearchParams) {
+  constructor(private url: IURLExtended, init: URLSearchParams) {
     super();
     this.params = init.params;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,8 @@
+import { URL as IURL } from 'url';
+
+export { URLSearchParams as IURLSearchParams } from 'url';
+
+export type IURLExtended = IURL & {
+    slashes: string;
+    origin: string;
+};

--- a/lib/url-search-params.ts
+++ b/lib/url-search-params.ts
@@ -1,11 +1,11 @@
-import { URLSearchParams as IURLSearchParams } from 'url';
 import {
   CODE_AMPERSAND,
   CODE_EQUALS,
   CODE_SPACE,
 } from './const';
+import { IURLSearchParams } from './types';
 
-export default class URLSearchParams implements IURLSearchParams {
+export default class SearchParams implements IURLSearchParams {
   public params: Array<[string, string]>;
   public isEncoded = false;
 
@@ -131,7 +131,7 @@ export function extractParams(
   urlString: string,
   start: number,
   end: number,
-  params: URLSearchParams,
+  params: SearchParams,
   separators: number[],
   equals: number,
   breakCodes: number[],

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,10 +1,10 @@
-import { URL as IURL } from 'url';
 import { CODE_FORWARD_SLASH, CODE_HASH, CODE_QUESTION_MARK } from './const';
 import ImmutableURL from './immutable-url';
 import URLSearchParamsWrapper from './search-params-wrapper';
+import { IURLExtended } from './types';
 import URLSearchParams from './url-search-params';
 
-function mutate(url: URL, changes: Partial<URL>): ImmutableURL {
+function mutate(url: IURLExtended, changes: Partial<IURLExtended>): ImmutableURL {
   const self = {
     hash: changes.hash !== undefined ? changes.hash : url.hash,
     host: changes.host !== undefined ? changes.host : url.host,
@@ -36,7 +36,7 @@ function mutate(url: URL, changes: Partial<URL>): ImmutableURL {
   );
 }
 
-export default class URL implements IURL {
+export default class implements IURLExtended {
   private url: ImmutableURL;
 
   constructor(url: string) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,13 +1,13 @@
-import URL from './url';
+import MutableURL from './url';
 
 /**
  * Checks if this URL's hostname is non-ascii, and if so returns a new URL with the hostname
  * punycoded. Otherwise returns itself.
  */
-export function getPunycodeEncoded(toASCII: (s: string) => string, url: URL) {
+export function getPunycodeEncoded(toASCII: (s: string) => string, url: MutableURL): MutableURL {
   const punycodedHost = toASCII(url.hostname);
   if (punycodedHost !== url.hostname) {
-    return new URL(`${url.protocol}${url.slashes}${punycodedHost}${url.pathname}${url.search}${url.hash}`);
+    return new MutableURL(`${url.protocol}${url.slashes}${punycodedHost}${url.pathname}${url.search}${url.hash}`);
   }
   return url;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2742,9 +2742,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5653,6 +5653,16 @@
         }
       }
     },
+    "rollup-plugin-sourcemaps": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz",
+      "integrity": "sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.0.1",
+        "source-map-resolve": "^0.5.0"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -6418,14 +6428,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
+      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "punycode": "^2.1.1",
     "rollup": "^1.16.2",
     "rollup-plugin-node-resolve": "^5.1.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
     "typescript": "^3.5.2",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,6 @@
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import resolve from 'rollup-plugin-node-resolve';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 
 export default [
   {
@@ -26,6 +27,7 @@ export default [
       resolve({
         preferBuiltins: false,
       }),
+      sourcemaps(),
       compiler(),
     ],
   },

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -1,4 +1,4 @@
-import { URL } from '../url-parser';
+import { URL } from '..';
 
 describe('Github', () => {
   it('Issue 22: Unable to set querystring', () => {

--- a/test/punycode.test.ts
+++ b/test/punycode.test.ts
@@ -1,5 +1,5 @@
 import { toASCII } from 'punycode';
-import { getPunycodeEncoded, URL } from '../url-parser';
+import { getPunycodeEncoded, URL } from '..';
 
 describe('getPunycodeEncoded', () => {
   it('Converts a non-ASCII hostname to punycode', () => {

--- a/test/url-search-params.test.ts
+++ b/test/url-search-params.test.ts
@@ -1,7 +1,7 @@
 import { URLSearchParams as NodeURLSearchParams } from 'url';
 // @ts-ignore
 import { URLSearchParams } from 'whatwg-url';
-import { URLSearchParams as TestURLSearchParams } from '../url-parser';
+import { URLSearchParams as TestURLSearchParams } from '..';
 
 type IURLSearchParams = NodeURLSearchParams | URLSearchParams | TestURLSearchParams;
 

--- a/test/url-spec.test.ts
+++ b/test/url-spec.test.ts
@@ -1,7 +1,7 @@
 import { toASCII } from 'punycode';
 // @ts-ignore
 import { URL as URLSpec } from 'whatwg-url';
-import { getPunycodeEncoded, URL } from '../url-parser';
+import { getPunycodeEncoded, URL } from '..';
 
 describe('URL Spec', () => {
   function compareParameters(u1: URLSpec, u2: URL) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "sourceMap": true,
     "declarationDir": "build/types",
-    "target": "es5",
+    "target": "es6",
     "module": "es6",
     "outDir": "build",
-    "lib": ["es6"],
     "moduleResolution": "Node",
     "esModuleInterop": true,
-    "importHelpers": true,
-    "downlevelIteration": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "forceConsistentCasingInFileNames": true,

--- a/url-parser.ts
+++ b/url-parser.ts
@@ -1,11 +1,4 @@
-import URL from './lib/url';
-import ImmutableURL from './lib/immutable-url';
-import URLSearchParams from './lib/url-search-params';
-import { getPunycodeEncoded } from './lib/utils';
-
-export {
-  URL,
-  ImmutableURL,
-  URLSearchParams,
-  getPunycodeEncoded,
-};
+export { default as URL } from './lib/url';
+export { default as ImmutableURL } from './lib/immutable-url';
+export { default as URLSearchParams } from './lib/url-search-params';
+export { getPunycodeEncoded } from './lib/utils';


### PR DESCRIPTION
To fix #4, I propose to bump the target of TypeScript compiler to `es6`, which allows to use generators and other features natively instead of requiring some polyfill. We should make sure it does not introduce any big regression but locally I could see that the figures I get for performance match roughly what's in the README (although I used a different hardware and Node.js version; it would be nice to check all original benchmarks). As a positive side-effect, the size of minified bundle is _6% smaller now_.

There was a few additional changes that needed to be made to satisfy the minifier (which does not like duplicated global class definitions since they are not transpiled to functions + prototypes now):

* Renaming `URLSearchParams` into `SearchParams`.
* Exporting classes as default and replacing direct class types by interface where possible.
* Renaming URL into MutableURL in `utils.ts` (I was wondering if it could return an ImmutableURL here as well?).

I added one last bit in the PR: correct source-map handling using an additional rollup plugin which is able to combine source-maps from dependencies (i.e. tldts) and url-parser code minified into a final one.